### PR TITLE
WIP: env vars for runs

### DIFF
--- a/content/source/docs/enterprise/run/index.html.md
+++ b/content/source/docs/enterprise/run/index.html.md
@@ -116,3 +116,32 @@ TFE uses [the `atlas` backend](/docs/backends/types/terraform-enterprise.html) t
 
 When TFE performs a run, it doesn't use existing user credentials; instead it generates a unique per-run API token, and exports it to the Terraform worker's shell environment as `$ATLAS_TOKEN`. This per-run token can read and write state data for the workspace associated with the run, and can read state data from any other workspace in the same organization. It cannot make any other calls to the TFE API. Per-run tokens are not considered to be user, team, or organization tokens, and become invalid after the run is completed.
 
+## Run Environment
+
+TFE performs Terraform runs on disposable Linux worker VMs using a POSIX-compatible shell. Before running Terraform, TFE populates the shell with environment variables using the `export` command.
+
+The environment variables in the worker VM include any [workspace environment variables](../workspaces/variables.html), plus several variables that TFE itself sets. In almost all cases, you should avoid setting workspace environment variables that conflict with these pre-set variables.
+
+The following is a list of TFE's pre-set environment variables. The full set isn't necessarily set for every run.
+
+Name(s) | Description
+--|--
+`TFE_TOKEN` / `ATLAS_TOKEN` | The unique per-run API token for this run. Used by the state backend to read/write state in the run's workspace and read state from other workspaces.
+`CHECKPOINT_DISABLE` | Set to `1` to support running Terraform in an automated environment.
+`TF_INPUT` | Set to `0` to support running Terraform in an automated environment.
+`TF_APPEND_USER_AGENT` | Reserved for internal use.
+`TFE_PARALLELISM` / `TF_ATLAS_PARALLELISM` | Reserved for internal use.
+`TFE_ADDRESS` / `ATLAS_ADDRESS` | The hostname of this TFE instance.
+
+
+Omitting:
+
+- `TF_ATLAS_DIR` (in the struct now?)
+- `ATLAS_RUN_ID` (struct?)
+- `ATLAS_CONFIGURATION_NAME` (can't tell the status of this?)
+- `ATLAS_CONFIGURATION_SLUG` (possibly coalesced into `SlugAddress` in the struct?)
+- `ATLAS_CONFIGURATION_VERSION` (is this `Version` in the struct?)
+- `ATLAS_CONFIGURATION_VERSION_GITHUB_BRANCH` (For this and the other two, models/runtime/run.rb makes it look like we're probably still setting them, but the name is obsolete, and they seem unlikely to stick around and be supportable in this form...?)
+- `ATLAS_CONFIGURATION_VERSION_GITHUB_COMMIT_SHA`
+- `ATLAS_CONFIGURATION_VERSION_GITHUB_TAG`
+


### PR DESCRIPTION
(DO NOT MERGE, this is just for pre-review.)

While trying to complete [this ticket](https://app.asana.com/0/390268369299573/687477957333412), to replace [this legacy page](https://www.terraform.io/docs/enterprise-legacy/runs/variables-and-configuration.html#environment-variables), I ran into some problems with figuring out which environment variables _exist,_ and which of those _matter._ 

As far as I can tell, we choose the values for environment variables in the Atlas code, at app/models/runtime/run.rb (?), and then we USE variables (if at all) in a combination of terraform-build-worker and Terraform itself (e.g. the atlas backend just reaches out to grab env vars). BUT, a lot of the variables we set seem dead (ish), because it looks like we switched to providing a lot of that data in the job struct we send to the worker instead. 

Also, after digging for a while, I had an existential moment, like, "who are we documenting this for, anyway?" My guesses were:

- So users don't stomp on any environment variables we rely on.
    - (Seems unlikely, but knowing more about the run environment adds to an aura of confidence, so may as well list em.) 
- So users can read values from our environment variables in order to do something within their terraform configs 
    - (how? AFAICT grabbing random stuff from the env isn't trivial.) 
    - (why? that seems like a fragile interface, and I don't know what the value of that data is to begin with.) 
- So users can set values for env vars that change the behavior of a TFE run, in ways that are too esoteric to justify being first-class members of the run request/UI — I neglected this when I was investigating this because I didn't think I saw any, but later realized that's probably what the parallelism variable is about. (Are there any more?)

Anyway: what did I get wrong in this list, and is documenting this even that good of an idea? 